### PR TITLE
FIX field parsing without django

### DIFF
--- a/rest_cereal/__init__.py
+++ b/rest_cereal/__init__.py
@@ -1,5 +1,15 @@
 import itertools
-from rest_framework.exceptions import APIException
+
+# This gross block of code is to allow you to use the
+# parse_fields_to_nested_tree methods without installing rest_framework/django
+import importlib
+rest_framework_loader = importlib.find_loader("rest_framework")
+django_installed = rest_framework_loader is not None
+if django_installed:
+    from rest_framework.exceptions import APIException
+else:
+    class APIException(Exception):
+        pass
 
 
 class CerealException(APIException):


### PR DESCRIPTION
Did import magic to stop django errors.

EX:

```
>>> importlib.find_loader
<function find_loader at 0x7f34aec57ae8>
>>> rfs = importlib.find_loader("rest_framework")
>>> rfs
<_frozen_importlib_external.SourceFileLoader object at 0x7f34ae9e5d68>
>>> rfs2 = importlib.find_loader("rest_frameworks")
>>> rfs2
>>> exit()
/code/src # python --version
Python 3.5.2
```